### PR TITLE
Solution: How to make the python pgxnclient work on Windows

### DIFF
--- a/pgxnclient/cli.py
+++ b/pgxnclient/cli.py
@@ -121,11 +121,11 @@ def command_dispatch(argv=None):
         # 
         # If env is not None, it must be a mapping that defines the environment variables 
         # for the new process; these are used instead of the default behavior of 
-        # inheriting the current process’ environment.
+        # inheriting the current processâ€™ environment. 
         # 
         # https://docs.python.org/3.3/library/subprocess.html#replacing-the-os-spawn-family
         # 
-        # os.exec on Windows
+        # os.exec on all Windows versions
         # http://stackoverflow.com/questions/7004687/os-exec-on-windows
         #
         # sys.executable: get current /path/to/python.exe that is being used

--- a/pgxnclient/cli.py
+++ b/pgxnclient/cli.py
@@ -121,7 +121,7 @@ def command_dispatch(argv=None):
         # 
         # If env is not None, it must be a mapping that defines the environment variables 
         # for the new process; these are used instead of the default behavior of 
-        # inheriting the current processâ€™ environment. 
+        # inheriting the current process environment. 
         # 
         # https://docs.python.org/3.3/library/subprocess.html#replacing-the-os-spawn-family
         # 

--- a/pgxnclient/cli.py
+++ b/pgxnclient/cli.py
@@ -114,7 +114,27 @@ def command_dispatch(argv=None):
         # through the current executable.
         argv.insert(0, sys.executable)
 
-    os.execv(argv[0], argv)
+    import platform
+    if platform.system() == 'Windows':
+        # 
+        # On Windows, the [Popen] class uses the Windows CreateProcess() function.
+        # 
+        # If env is not None, it must be a mapping that defines the environment variables 
+        # for the new process; these are used instead of the default behavior of 
+        # inheriting the current process’ environment.
+        # 
+        # https://docs.python.org/3.3/library/subprocess.html#replacing-the-os-spawn-family
+        # 
+        # os.exec on Windows
+        # http://stackoverflow.com/questions/7004687/os-exec-on-windows
+        #
+        # sys.executable: get current /path/to/python.exe that is being used
+        # 
+        import subprocess
+        all_argv = [sys.executable] + argv
+        subprocess.call(all_argv) 
+    else:
+        os.execv(argv[0], argv)
 
 def _get_exec(cmd):
     fn = find_script('pgxn-' + cmd)

--- a/pgxnclient/commands/__init__.py
+++ b/pgxnclient/commands/__init__.py
@@ -217,6 +217,18 @@ class Command(object):
         """
         logger.debug("running command: %s", cmd)
         try:
+            import platform
+            if platform.system() == 'Windows':
+                import re
+                if isinstance(cmd, (list, tuple)):
+                    if re.search('configure$', cmd[0]):
+                        cmd[0] = 'sh ./configure'
+                if isinstance(cmd, str):
+                    if re.search('configure$', cmd):
+                        cmd = 'sh ./configure'
+            else:
+                cmd = cmd
+
             return Popen(cmd, *args, **kwargs)
         except OSError, e:
             if not isinstance(cmd, basestring):
@@ -546,7 +558,17 @@ class WithMake(WithPgConfig):
         if sudo:
             cmdline.extend(shlex.split(sudo))
 
-        cmdline.extend([self.get_make(), 'PG_CONFIG=%s' % self.get_pg_config()])
+        import platform
+        if platform.system() == 'Windows':
+            # remove colons ':'
+            # if a character exists at the beginning and if it is upper case, then make it lowercase
+            # append a backslash '/' to the beginning of the line
+            # replace occurances of '\\' with '/' 
+            import re
+            new_pg_config = ('/' + re.sub("^[A-Z]", lambda m: m.group(0).lower(),self.get_pg_config().replace(":",""))).replace("\\","/")
+            cmdline.extend([self.get_make(), 'PG_CONFIG=%s' % new_pg_config])
+        else:
+            cmdline.extend([self.get_make(), 'PG_CONFIG=%s' % self.get_pg_config()])
 
         if isinstance(cmd, basestring):
             cmdline.append(cmd)

--- a/pgxnclient/commands/__init__.py
+++ b/pgxnclient/commands/__init__.py
@@ -230,6 +230,7 @@ class Command(object):
                 cmd = cmd
 
             return Popen(cmd, *args, **kwargs)
+
         except OSError, e:
             if not isinstance(cmd, basestring):
                 cmd = ' '.join(cmd)

--- a/pgxnclient/commands/__init__.py
+++ b/pgxnclient/commands/__init__.py
@@ -460,13 +460,13 @@ class WithPgConfig(object):
 
         import platform
         if platform.system() == 'Windows':
-          subp.add_argument('--pg_config', metavar="PROG", default='pg_config.exe',
-              help = _("the pg_config executable to find the database"
-                  " [default: %(default)s]"))
+            subp.add_argument('--pg_config', metavar="PROG", default='pg_config.exe',
+                help = _("the pg_config executable to find the database"
+                    " [default: %(default)s]"))
         else:
-          subp.add_argument('--pg_config', metavar="PROG", default='pg_config',
-              help = _("the pg_config executable to find the database"
-                  " [default: %(default)s]"))
+            subp.add_argument('--pg_config', metavar="PROG", default='pg_config',
+                help = _("the pg_config executable to find the database"
+                    " [default: %(default)s]"))
 
         return subp
 

--- a/pgxnclient/commands/__init__.py
+++ b/pgxnclient/commands/__init__.py
@@ -593,10 +593,17 @@ class WithMake(WithPgConfig):
 
     @classmethod
     def _find_default_make(self):
-        for make in ('gmake', 'make'):
-            path = find_executable(make)
-            if path:
-                return make
+        import platform
+        if platform.system() == 'Windows':
+            for make in ('gmake.exe', 'make.exe'):
+                path = find_executable(make)
+                if path:
+                    return make
+        else:
+            for make in ('gmake', 'make'):
+                path = find_executable(make)
+                if path:
+                    return make
 
         # if nothing was found, fall back on 'gmake'. If it was missing we
         # will give an error when attempting to use it

--- a/pgxnclient/commands/__init__.py
+++ b/pgxnclient/commands/__init__.py
@@ -458,9 +458,15 @@ class WithPgConfig(object):
         subp = super(WithPgConfig, self).customize_parser(
             parser, subparsers, **kwargs)
 
-        subp.add_argument('--pg_config', metavar="PROG", default='pg_config',
-            help = _("the pg_config executable to find the database"
-                " [default: %(default)s]"))
+        import platform
+        if platform.system() == 'Windows':
+          subp.add_argument('--pg_config', metavar="PROG", default='pg_config.exe',
+              help = _("the pg_config executable to find the database"
+                  " [default: %(default)s]"))
+        else:
+          subp.add_argument('--pg_config', metavar="PROG", default='pg_config',
+              help = _("the pg_config executable to find the database"
+                  " [default: %(default)s]"))
 
         return subp
 

--- a/pgxnclient/commands/__init__.py
+++ b/pgxnclient/commands/__init__.py
@@ -564,7 +564,7 @@ class WithMake(WithPgConfig):
             # remove colons ':'
             # if a character exists at the beginning and if it is upper case, then make it lowercase
             # append a backslash '/' to the beginning of the line
-            # replace occurances of '\\' with '/' 
+            # replace many occurances of '\\' with '/' 
             import re
             new_pg_config = ('/' + re.sub("^[A-Z]", lambda m: m.group(0).lower(),self.get_pg_config().replace(":",""))).replace("\\","/")
             cmdline.extend([self.get_make(), 'PG_CONFIG=%s' % new_pg_config])
@@ -629,7 +629,7 @@ class WithMake(WithPgConfig):
                     return make
 
         # if nothing was found, fall back on 'gmake'. If it was missing we
-        # will give an error when attempting to use it
+        # will give an error when attempting to use it. 
         return 'gmake'
 
 
@@ -704,4 +704,3 @@ variables PGDATABASE, PGHOST, PGPORT, PGUSER.
         if self.opts.port: rv['PGPORT'] = str(self.opts.port)
         if self.opts.username: rv['PGUSER'] = self.opts.username
         return rv
-


### PR DESCRIPTION
To make the python client pgxnclient-1.2.1 work on Windows, do the following.
Prepare to make changes to the source code of the python client pgxnclient-1.2.1.

In the file
pgxnclient-1.2.1\pgxnclient-1.2.1\pgxnclient\cli.py
change this line

from ( line 114 )

``` python
    os.execv(argv[0], argv)
```

to ( new lines at 114+ )

``` python
    import platform
    if platform.system() == 'Windows':
        #
        # On Windows, the [Popen] class uses the Windows CreateProcess() function.
        #
        # If env is not None, it must be a mapping that defines the environment variables 
        # for the new process; these are used instead of the default behavior of 
        # inheriting the current process’ environment.
        # 
        # https://docs.python.org/3.3/library/subprocess.html#replacing-the-os-spawn-family
        # 
        # os.exec on Windows
        # http://stackoverflow.com/questions/7004687/os-exec-on-windows
        #
        # sys.executable: get current /path/to/python.exe that is being used
        # 
        import subprocess
        all_argv = [sys.executable] + argv
        subprocess.call(all_argv) 
    else:
        os.execv(argv[0], argv)
```

In this file
pgxnclient-1.2.1\pgxnclient-1.2.1\pgxnclient\commands__init__.py
change

from

``` python
        subp.add_argument('--pg_config', metavar="PROG", default='pg_config',
            help = _("the pg_config executable to find the database"
                " [default: %(default)s]"))
```

to

``` python
        import platform
        if platform.system() == 'Windows':
          subp.add_argument('--pg_config', metavar="PROG", default='pg_config.exe',
              help = _("the pg_config executable to find the database"
                  " [default: %(default)s]"))
        else:
          subp.add_argument('--pg_config', metavar="PROG", default='pg_config',
              help = _("the pg_config executable to find the database"
                  " [default: %(default)s]"))
```

Also, In this same file
pgxnclient-1.2.1\pgxnclient-1.2.1\pgxnclient\commands__init__.py
change

from

``` python
    def _find_default_make(self):

        for make in ('gmake', 'make'):
            path = find_executable(make)
            if path:
                return make
```

to

``` python
    def _find_default_make(self):

        import platform
        if platform.system() == 'Windows':
          for make in ('gmake.exe', 'make.exe'):
              path = find_executable(make)
              if path:
                  return make
        else:
          for make in ('gmake', 'make'):
              path = find_executable(make)
              if path:
                  return make
```

That works with the following caveats.

This is my working environment.

```
1. Only working in MSYS ( not the windows command shell. )
```

```
2. Only working with a path that looks like this.

$  echo $PATH
/c/EnterpriseDB/LanguagePack/9.5/x64/Python-3.3:/c/EnterpriseDB/LanguagePack/9.5/x64/Python-3.3/Scripts:/c/MinGW/msys/1.0/local/pgsql_0ab9c56_debug/bin:.:/usr/local/bin:/mingw/bin:/bin:/c/Windows/system32:/c/Windows:/c/Windows/System32/Wbem:/c/Windows/Sys
tem32/WindowsPowerShell/v1.0/
```

``````
3. Fulling testing that my pg_config produces the correct output 
 a. right facing slashes n MSYS
 b. correct paths

before starting.  For example mine looks like. 
```shell
$  pg_config
BINDIR = c:/MinGW/msys/1.0/local/PGSQL_~4/bin
DOCDIR = c:/MinGW/msys/1.0/local/PGSQL_~4/share/doc
HTMLDIR = c:/MinGW/msys/1.0/local/PGSQL_~4/share/doc
INCLUDEDIR = c:/MinGW/msys/1.0/local/PGSQL_~4/include
PKGINCLUDEDIR = c:/MinGW/msys/1.0/local/PGSQL_~4/include
INCLUDEDIR-SERVER = c:/MinGW/msys/1.0/local/PGSQL_~4/include/server
LIBDIR = c:/MinGW/msys/1.0/local/PGSQL_~4/lib
PKGLIBDIR = c:/MinGW/msys/1.0/local/PGSQL_~4/lib
LOCALEDIR = c:/MinGW/msys/1.0/local/pgsql_0ab9c56_debug/share/locale
MANDIR = c:/MinGW/msys/1.0/local/pgsql_0ab9c56_debug/share/man
SHAREDIR = c:/MinGW/msys/1.0/local/PGSQL_~4/share
SYSCONFDIR = c:/MinGW/msys/1.0/local/pgsql_0ab9c56_debug/etc
PGXS = c:/MinGW/msys/1.0/local/PGSQL_~4/lib/pgxs/src/MAKEFI~1/pgxs.mk
CONFIGURE = '--with-tcl' '--with-python' '--with-perl' '--with-includes=/c/Users/TargetUser/Documents/zlib-1.2.8-win32-x86_64/include' '--with-libraries=/c/Users/TargetUser/Documents/zlib-1.2.8-win32-x86_64/lib' '--host=x86_64-w64-mingw32' '--prefix
=/usr/local/pgsql_0ab9c56_debug' '--disable-rpath' '--enable-depend' '--enable-cassert' '--enable-debug' '--with-extra-version=_CFLAGS_O_0ab9c56' 'CFLAGS=-O -fno-omit-frame-pointer' 'host_alias=x86_64-w64-mingw32'
CC = x86_64-w64-mingw32-gcc
CPPFLAGS = -DFRONTEND -I./src/include/port/win32 -DEXEC_BACKEND -I/c/Users/TargetUser/Documents/zlib-1.2.8-win32-x86_64/include -I../../src/include/port/win32 -DBUILDING_DLL
CFLAGS = -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -g -O -fno-omit-frame-pointer
CFLAGS_SL =
LDFLAGS = -L../../src/common -Wl,--allow-multiple-definition -Wl,--disable-auto-import -L/c/Users/TargetUser/Documents/zlib-1.2.8-win32-x86_64/lib -Wl,--as-needed
LDFLAGS_EX =
LDFLAGS_SL =
LIBS = -lpgcommon -lpgport -lz -lws2_32 -lm  -lws2_32
VERSION = PostgreSQL 10devel_CFLAGS_O_0ab9c56
``````

```
4. if the source Makefile contains the word: $(PG_CONFIG),
and upon each run of the make on the Makefile that goes through that region,
the case seem that the following error is produced.
```

``` shell
/bin/sh: c:MinGWmsys1.0localpgsql_0ab9c56_debugbinpg_config.exe: command not found
```

The working solution is protect $(PG_CONFIG) by putting double quotes around it.

So this  $(PG_CONFIG)
becomes "$(PG_CONFIG)"

For example

change

``` shell
PG91         = $(shell $(PG_CONFIG) --version | grep -qE " 8\.| 9\.0" && echo no || echo yes)
```

and

``` shell
PGXS := $(shell "$(PG_CONFIG)" --pgxs)
```

to

``` shell
PG91         = $(shell "$(PG_CONFIG)" --version | grep -qE " 8\.| 9\.0" && echo no || echo yes)
```

and

``` shell
PGXS := $(shell "$(PG_CONFIG)" --pgxs)
```

The way to do this is to intercept the Makefile before it gets 'read and ran' by make.

In the code, place a python breakpoint, perhaps, just before 
the runtime call to Popen.
The information below shows how to do that.

In the file
pgxnclient-1.2.1\pgxnclient\commands__init__.py
in the implementation of

``` python
def popen(self, cmd, *args, **kwargs):
```

and just before the 'return Popen(cmd, _args, *_kwargs)

Change from

``` python
return Popen(cmd, *args, **kwargs)
```

to

``` python
import pdb; pdb.set_trace()
return Popen(cmd, *args, **kwargs)
```

Now all code changes are now done.

Now install ( or re-install ) the python client pgxnclient-1.2.1

``` shell
python setup.py install
```

To see the path to the Makefile run in verbose mode

``` shell
$ pgxn install pair --verbose
```

The python program will pause at the breakpoint

``` python
(Pdb)
```

Look at the screen for the output of the line that has the path to the Makefile.
It looks something like this.

``` shell
c:\users\anonym~1\appdata\local\temp\tmp6d0lpe\pair-0.1.5\Makefile
```

In Notpad++ or a similar editor, open the Makefile, and prepare to edit it. 
For example, open the pair extension 'temporory' Makefile

``` shell
c:\users\anonym~1\appdata\local\temp\tmp6d0lpe\pair-0.1.5\Makefile
```

then make the changes in the Makefile.

Change these

``` shell
PG91         = $(shell $(PG_CONFIG) --version | grep -qE " 8\.| 9\.0" && echo no || echo yes)
```

and

``` shell
PGXS := $(shell "$(PG_CONFIG)" --pgxs)
```

to these

``` shell
PG91         = $(shell "$(PG_CONFIG)" --version | grep -qE " 8\.| 9\.0" && echo no || echo yes)
```

and

``` shell
PGXS := $(shell "$(PG_CONFIG)" --pgxs)
```

In Notepad++, press Save.

Press 'c' to continue

```
(Pdb) c
```

Everytime the program pauses, press 'c' again until the install finishes.

``` python
(Pdb) c
```

Note, not 'all' pgxn Makefiles contain $(PG_CONFIG),
for example 'quantile' does not.

```
https://github.com/tvondra/quantile/blob/master/Makefile
http://pgxn.org/dist/quantile/
```

Here is my quantile pgxn extension installation on windows.
(Note, this is  much more than --verbose and python breakpoints will show.
I have much extra debugging print statements and many more python breakpoints)

``` shell
Targetuser@TARGETMACH /c/Users/Targetuser/Downloads/pgxnclient-1.2.1
$
$ pgxn install quantile --verbose

ArgumentParser(prog='pgxn', usage=None, description='Interact with the PostgreSQL Extension Network (PGXN).', version=None, formatter_class=<class 'pgxnclient.utils.argparse.HelpFormatter'>, conflict_handler='error', add_help=True)
Namespace(cmd=<class 'pgxnclient.commands.install.Install'>, make='make.exe', mirror='http://api.pgxn.org/', pg_config='pg_config.exe', spec='quantile', status=2, sudo=None, verbose=True, yes=False)
> c:\enterprisedb\languagepack\9.5\x64\python-3.3\lib\site-packages\pgxnclient-1.2.1-py3.3.egg\pgxnclient\commands\__init__.py(95)run_command()
-> logging.getLogger().setLevel(
(Pdb) c
DEBUG: running pg_config --libdir
> c:\enterprisedb\languagepack\9.5\x64\python-3.3\lib\site-packages\pgxnclient-1.2.1-py3.3.egg\pgxnclient\commands\__init__.py(219)popen()
-> logger.debug("running command: %s", cmd)
(Pdb) c
DEBUG: running command: ['c:\\MinGW\\msys\\1.0\\local\\pgsql_0ab9c56_debug\\bin\\pg_config.exe', '--libdir']
()
{'stdout': -1}
<subprocess.Popen object at 0x0000000002E2EDD8>
DEBUG: testing if c:/MinGW/msys/1.0/local/PGSQL_~4/lib is writable
DEBUG: opening url: http://api.pgxn.org/index.json
DEBUG: opening url: http://api.pgxn.org/dist/quantile.json
INFO: best version: quantile 1.1.5
DEBUG: opening url: http://api.pgxn.org/dist/quantile/1.1.5/META.json
DEBUG: opening url: http://api.pgxn.org/dist/quantile/1.1.5/quantile-1.1.5.zip
INFO: saving c:\users\anonym~1\appdata\local\temp\tmpnb776o\quantile-1.1.5.zip
DEBUG: checking sha1 of 'c:\users\anonym~1\appdata\local\temp\tmpnb776o\quantile-1.1.5.zip'
INFO: unpacking: c:\users\anonym~1\appdata\local\temp\tmpnb776o\quantile-1.1.5.zip
DEBUG: saving: c:\users\anonym~1\appdata\local\temp\tmpnb776o\quantile-1.1.5\.gitignore
DEBUG: saving: c:\users\anonym~1\appdata\local\temp\tmpnb776o\quantile-1.1.5\LICENSE
DEBUG: saving: c:\users\anonym~1\appdata\local\temp\tmpnb776o\quantile-1.1.5\META.json
DEBUG: saving: c:\users\anonym~1\appdata\local\temp\tmpnb776o\quantile-1.1.5\Makefile
DEBUG: saving: c:\users\anonym~1\appdata\local\temp\tmpnb776o\quantile-1.1.5\README.md
DEBUG: saving: c:\users\anonym~1\appdata\local\temp\tmpnb776o\quantile-1.1.5\quantile.control
DEBUG: saving: c:\users\anonym~1\appdata\local\temp\tmpnb776o\quantile-1.1.5\sql\quantile--1.1.4--1.1.5.sql
DEBUG: saving: c:\users\anonym~1\appdata\local\temp\tmpnb776o\quantile-1.1.5\sql\quantile--1.1.5.sql
DEBUG: saving: c:\users\anonym~1\appdata\local\temp\tmpnb776o\quantile-1.1.5\src\quantile.c
DEBUG: saving: c:\users\anonym~1\appdata\local\temp\tmpnb776o\quantile-1.1.5\test\expected\base.out
DEBUG: saving: c:\users\anonym~1\appdata\local\temp\tmpnb776o\quantile-1.1.5\test\sql\base.sql
Namespace(cmd=<class 'pgxnclient.commands.install.Install'>, make='make.exe', mirror='http://api.pgxn.org/', pg_config='pg_config.exe', spec='quantile', status=2, sudo=None, target='c:\\users\\anonym~1\\appdata\\local\\temp\\tmpnb776o', verbose=True, yes=
False)
> c:\enterprisedb\languagepack\9.5\x64\python-3.3\lib\site-packages\pgxnclient-1.2.1-py3.3.egg\pgxnclient\commands\install.py(125)maybe_run_configure()
-> fn = os.path.join(dir, 'configure')
(Pdb) c
DEBUG: checking 'c:\users\anonym~1\appdata\local\temp\tmpnb776o\quantile-1.1.5\configure'
INFO: building extension
DEBUG: running: ['make.exe', 'PG_CONFIG=c:\\MinGW\\msys\\1.0\\local\\pgsql_0ab9c56_debug\\bin\\pg_config.exe', 'all']
> c:\enterprisedb\languagepack\9.5\x64\python-3.3\lib\site-packages\pgxnclient-1.2.1-py3.3.egg\pgxnclient\commands\__init__.py(219)popen()
-> logger.debug("running command: %s", cmd)
(Pdb) c
DEBUG: running command: ['make.exe', 'PG_CONFIG=c:\\MinGW\\msys\\1.0\\local\\pgsql_0ab9c56_debug\\bin\\pg_config.exe', 'all']
()
{'close_fds': True, 'env': None, 'cwd': 'c:\\users\\anonym~1\\appdata\\local\\temp\\tmpnb776o\\quantile-1.1.5', 'shell': False}
<subprocess.Popen object at 0x0000000002D8BF28>
x86_64-w64-mingw32-gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -g -O -fno-omit-frame-pointer   -I. -I./ -
IC:/MinGW/msys/1.0/local/PGSQL_~4/include/server -IC:/MinGW/msys/1.0/local/PGSQL_~4/include/internal -I./src/include/port/win32 -DEXEC_BACKEND  -I/c/Users/Targetuser/Documents/zlib-1.2.8-win32-x86_64/include -IC:/MinGW/msys/1.0/local/PGSQL_~4/include/s
erver/port/win32  -c -o src/quantile.o src/quantile.c -MMD -MP -MF .deps/quantile.Po
x86_64-w64-mingw32-gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -g -O -fno-omit-frame-pointer    -shared -
static-libgcc -o quantile.dll  src/quantile.o -LC:/MinGW/msys/1.0/local/PGSQL_~4/lib -Wl,--allow-multiple-definition -Wl,--disable-auto-import  -L/c/Users/Targetuser/Documents/zlib-1.2.8-win32-x86_64/lib -Wl,--as-needed  -LC:/MinGW/msys/1.0/local/PGSQL
_~4/lib -lpostgres -lpgcommon -lpgport -lz -lws2_32 -lm  -lws2_32 -Wl,--export-all-symbols -Wl,--out-implib=libquantile.a
INFO: installing extension
DEBUG: testing if c:/MinGW/msys/1.0/local/PGSQL_~4/lib is writable
DEBUG: running: ['make.exe', 'PG_CONFIG=c:\\MinGW\\msys\\1.0\\local\\pgsql_0ab9c56_debug\\bin\\pg_config.exe', 'install']
 c:\enterprisedb\languagepack\9.5\x64\python-3.3\lib\site-packages\pgxnclient-1.2.1-py3.3.egg\pgxnclient\commands\__init__.py(219)popen()
> logger.debug("running command: %s", cmd)
Pdb) c
EBUG: running command: ['make.exe', 'PG_CONFIG=c:\\MinGW\\msys\\1.0\\local\\pgsql_0ab9c56_debug\\bin\\pg_config.exe', 'install']
)
'close_fds': True, 'env': None, 'cwd': 'c:\\users\\anonym~1\\appdata\\local\\temp\\tmpnb776o\\quantile-1.1.5', 'shell': False}<subprocess.Popen object at 0x0000000002EC9160>
/bin/mkdir -p 'C:/MinGW/msys/1.0/local/PGSQL_~4/lib'
/bin/mkdir -p 'C:/MinGW/msys/1.0/local/PGSQL_~4/share/extension'
/bin/mkdir -p 'C:/MinGW/msys/1.0/local/PGSQL_~4/share/extension'
/bin/mkdir -p 'C:/MinGW/msys/1.0/local/PGSQL_~4/lib'
/bin/install -c -m 755  quantile.dll 'C:/MinGW/msys/1.0/local/PGSQL_~4/lib/quantile.dll'
/bin/install -c -m 644 .//quantile.control 'C:/MinGW/msys/1.0/local/PGSQL_~4/share/extension/'
/bin/install -c -m 644 .//sql/quantile--1.1.5.sql .//sql/quantile--1.1.4--1.1.5.sql  'C:/MinGW/msys/1.0/local/PGSQL_~4/share/extension/'
/bin/install -c -m 755  quantile.dll 'C:/MinGW/msys/1.0/local/PGSQL_~4/lib/'

Targetuser@TARGETMACH /c/Users/Targetuser/Downloads/pgxnclient-1.2.1
$
```

This pull request only contains that change of using 

```
  1. subprocess.call(window) instead of os.execv(non-windows) and 
  2. "gmake.exe" and "make.exe" instead of "gmake" and "make."
```

Andre Mikulec
Andre_Mikulec@Hotmail.com
