### PR TITLE
Fix parse PostgreSQL version.

### DIFF
--- a/pgxnclient/commands/install.py
+++ b/pgxnclient/commands/install.py
@@ -246,7 +246,7 @@ class LoadUnload(WithPgConfig, WithDatabase, WithSpecUrl, WithSpecLocal, Command
 
     def get_pg_version(self):
         """Return the version of the selected database."""
-        data = self.call_psql('SELECT version();')
+        data = self.call_psql('SHOW server_version;')
         pgver = self.parse_pg_version(data)
         logger.debug("PostgreSQL version: %d.%d.%d", *pgver)
         return pgver

--- a/pgxnclient/commands/install.py
+++ b/pgxnclient/commands/install.py
@@ -254,10 +254,22 @@ class LoadUnload(WithPgConfig, WithDatabase, WithSpecUrl, WithSpecLocal, Command
     def parse_pg_version(self, data):
         m = re.match(r'\S+\s+(\d+)\.(\d+)(?:\.(\d+))?', data)
         if m is None:
-            raise PgxnClientException(
-                "cannot parse version number from '%s'" % data)
+            m = re.match( r'\S+\s+(\d+)beta(\d+)', data )
+            is_beta = True
+            if m is None:
+                raise PgxnClientException(
+                    "cannot parse version number from '%s'" % data)
+        else:
+            is_beta = False
 
-        return (int(m.group(1)), int(m.group(2)), int(m.group(3) or 0))
+        major = int( m.group( 1 ) )
+        minor = int( m.group( 2 ) )
+        if is_beta:
+            patch = 99
+        else:
+            patch = int( m.group( 3 ) or 0 )
+
+        return ( major, minor, patch )
 
     def is_extension(self, name):
         fn = os.path.join(self.call_pg_config('sharedir'),

--- a/pgxnclient/commands/install.py
+++ b/pgxnclient/commands/install.py
@@ -252,9 +252,9 @@ class LoadUnload(WithPgConfig, WithDatabase, WithSpecUrl, WithSpecLocal, Command
         return pgver
 
     def parse_pg_version(self, data):
-        m = re.match(r'\S+\s+(\d+)\.(\d+)(?:\.(\d+))?', data)
+        m = re.match(r'^(\d+)\.(\d+)(?:\.(\d+))?', data)
         if m is None:
-            m = re.match( r'\S+\s+(\d+)beta(\d+)', data )
+            m = re.match( r'^(\d+)beta(\d+)', data )
             is_beta = True
             if m is None:
                 raise PgxnClientException(


### PR DESCRIPTION
The regular expression matching the version string expects three digits,
but in the case of a beta version it does includes the 'beta' keyword.
Therefore, there is a second regular exception triggering the above case.

Close #29